### PR TITLE
Add CUDA 11.4 module to ease the switch to newer CUDA

### DIFF
--- a/cuda-modules/cuda/11.4
+++ b/cuda-modules/cuda/11.4
@@ -1,0 +1,43 @@
+#%Module1.0#####################################################################
+##
+## modules cuda/11.4
+##
+## modulefiles/cuda/11.4. Written by Quentin Anthony
+##
+proc ModulesHelp { } {
+        global version prefix
+
+        puts stderr "cuda/11.4 - Sets the environment for CUDA 11.4"
+}
+
+module-whatis   "Sets the environment for using CUDA 11.4 (including NCCL builds)"
+
+# for Tcl script use only
+set     version         11.4
+set     prefix          /usr/share/Modules
+set     exec_prefix     /usr/share/Modules
+set     datarootdir     ${prefix}/share
+
+# CUDA paths
+prepend-path    PATH                /usr/local/cuda-11.4/bin
+prepend-path    CPATH               /usr/local/cuda-11.4/include
+prepend-path    MANPATH             /usr/local/cuda-11.4/share/man
+prepend-path    LD_LIBRARY_PATH     /usr/local/cuda-11.4/lib64
+prepend-path    LIBRARY_PATH        /usr/local/cuda-11.4/lib64
+prepend-path    CUDA_HOME           /usr/local/cuda-11.4
+
+# NCCL paths
+prepend-path    CPATH               /opt/nccl/build/include
+prepend-path    LD_LIBRARY_PATH     /opt/nccl/build/lib
+prepend-path    LIBRARY_PATH        /opt/nccl/build/lib
+prepend-path    NCCL_HOME           /opt/nccl/build
+
+# AWS-OFI-NCCL paths
+prepend-path    LD_LIBRARY_PATH     /opt/aws-ofi-nccl/lib
+prepend-path    LIBRARY_PATH        /opt/aws-ofi-nccl/lib
+prepend-path    AWS_OFI_NCCL_HOME   /opt/aws-ofi-nccl
+
+# nccl-tests paths
+prepend-path    PATH               /opt/nccl-tests/build
+
+#module         use

--- a/modules/43.allow.nvidia.debug.gpu.sh
+++ b/modules/43.allow.nvidia.debug.gpu.sh
@@ -17,7 +17,7 @@ installDCGM() {
 
 bumpUp(){
     yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
-    yum -y install cuda-toolkit-11-6 libcudnn8 libcudnn8-devel
+    yum -y install cuda-toolkit-11-6 cuda-toolkit-11-4 libcudnn8 libcudnn8-devel
 }
 
 installCudaModules(){


### PR DESCRIPTION
New cluster updates shouldn't totally break user setups. Installing all CUDA versions and providing modules makes the switch to newer CUDA optional and easier.